### PR TITLE
Use correct GitHub username in package.json urls

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "fuzzy",
   "description": "small, standalone fuzzy search / fuzzy filter. browser or node",
   "version": "0.1.0",
-  "homepage": "https://github.com/myork/fuzzy",
+  "homepage": "https://github.com/mattyork/fuzzy",
   "author": {
     "name": "Matt York",
     "email": "york.matt@gmail.com",
@@ -10,15 +10,15 @@
   },
   "repository": {
     "type": "git",
-    "url": "git://github.com/myork/fuzzy.git"
+    "url": "git://github.com/mattyork/fuzzy.git"
   },
   "bugs": {
-    "url": "https://github.com/myork/fuzzy/issues"
+    "url": "https://github.com/mattyork/fuzzy/issues"
   },
   "licenses": [
     {
       "type": "MIT",
-      "url": "https://github.com/myork/fuzzy/blob/master/LICENSE-MIT"
+      "url": "https://github.com/mattyork/fuzzy/blob/master/LICENSE-MIT"
     }
   ],
   "main": "lib/fuzzy",


### PR DESCRIPTION
I came across Fuzzy on NPM. Looks pretty cool, but when trying to get to the GitHub repo, I noticed the GitHub urls were broken. This remedies that.