### PR TITLE
Fix repo URL in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "fuzzy",
   "description": "small, standalone fuzzy search / fuzzy filter. browser or node",
   "version": "0.1.0",
-  "homepage": "https://github.com/myork/fuzzy",
+  "homepage": "https://github.com/mattyork/fuzzy",
   "author": {
     "name": "Matt York",
     "email": "york.matt@gmail.com",
@@ -10,15 +10,15 @@
   },
   "repository": {
     "type": "git",
-    "url": "git://github.com/myork/fuzzy.git"
+    "url": "git://github.com/mattyork/fuzzy.git"
   },
   "bugs": {
-    "url": "https://github.com/myork/fuzzy/issues"
+    "url": "https://github.com/mattyork/fuzzy/issues"
   },
   "licenses": [
     {
       "type": "MIT",
-      "url": "https://github.com/myork/fuzzy/blob/master/LICENSE-MIT"
+      "url": "https://github.com/mattyork/fuzzy/blob/master/LICENSE-MIT"
     }
   ],
   "main": "lib/fuzzy",


### PR DESCRIPTION
The [npm page for fuzzy](https://www.npmjs.com/package/fuzzy) refers to:

  * <https://github.com/myork/fuzzy>

Which is a 404. Hopefully that fixes it :)