### PR TITLE
Add error handling and fallback for .filter

### DIFF
--- a/lib/fuzzy.js
+++ b/lib/fuzzy.js
@@ -102,6 +102,14 @@ fuzzy.match = function(pattern, string, opts) {
 //      , extract: function(arg) { return arg.crying; }
 //    }
 fuzzy.filter = function(pattern, arr, opts) {
+  if( !(arr && arr.length > 0) ) {
+    return []
+  }
+
+  if (pattern == undefined) {
+    return arr
+  }
+
   opts = opts || {};
   return arr
     .reduce(function(prev, element, idx, arr) {

--- a/lib/fuzzy.js
+++ b/lib/fuzzy.js
@@ -105,11 +105,9 @@ fuzzy.filter = function(pattern, arr, opts) {
   if( !(arr && arr.length > 0) ) {
     return []
   }
-
   if (pattern == undefined) {
     return arr
   }
-
   opts = opts || {};
   return arr
     .reduce(function(prev, element, idx, arr) {

--- a/lib/fuzzy.js
+++ b/lib/fuzzy.js
@@ -102,10 +102,10 @@ fuzzy.match = function(pattern, string, opts) {
 //      , extract: function(arg) { return arg.crying; }
 //    }
 fuzzy.filter = function(pattern, arr, opts) {
-  if( !(arr && arr.length > 0) ) {
+  if(!arr || arr.length === 0) {
     return []
   }
-  if (pattern == undefined) {
+  if (typeof pattern !== 'string') {
     return arr
   }
   opts = opts || {};

--- a/package.json
+++ b/package.json
@@ -25,9 +25,11 @@
   "engines": {
     "node": ">= 0.6.0"
   },
+
   "scripts": {
     "test": "make test"
   },
+
   "devDependencies": {
     "mocha": ">= 1.3.0",
     "chai": ">= 1.1.1",

--- a/package.json
+++ b/package.json
@@ -25,11 +25,9 @@
   "engines": {
     "node": ">= 0.6.0"
   },
-
   "scripts": {
     "test": "make test"
   },
-
   "devDependencies": {
     "mocha": ">= 1.3.0",
     "chai": ">= 1.1.1",

--- a/test/fuzzy.test.js
+++ b/test/fuzzy.test.js
@@ -71,19 +71,16 @@ describe('fuzzy', function(){
       var result = fuzzy.filter(undefined, arr);
       expect(result).to.include.members(arr)
     })
-
     it('should return an empty array when the array is undefined', function() {
       var result = fuzzy.filter('pattern', undefined);
       expect(result).to.deep.equal([])
       expect(result).to.be.empty;
     })
-
     it('should return an empty array when the array is empty', function() {
       var result = fuzzy.filter('pattern', []);
       expect(result).to.deep.equal([])
       expect(result).to.be.empty;
     })
-
     it('should return the index and matching array elements', function(){
       var result = fuzzy.filter('ab', ['aba', 'c', 'cacb']);
       expect(result).to.have.length(2);

--- a/test/fuzzy.test.js
+++ b/test/fuzzy.test.js
@@ -64,7 +64,26 @@ describe('fuzzy', function(){
       expect(result).to.equal('<r><e>active r<i><c>e');
     });
   });
+
   describe('.filter', function(){
+    it('should return list untouched when the pattern is undefined', function() {
+      arr = ['aba', 'c', 'cacb']
+      var result = fuzzy.filter(undefined, arr);
+      expect(result).to.include.members(arr)
+    })
+
+    it('should return an empty array when the array is undefined', function() {
+      var result = fuzzy.filter('pattern', undefined);
+      expect(result).to.deep.equal([])
+      expect(result).to.be.empty;
+    })
+
+    it('should return an empty array when the array is empty', function() {
+      var result = fuzzy.filter('pattern', []);
+      expect(result).to.deep.equal([])
+      expect(result).to.be.empty;
+    })
+
     it('should return the index and matching array elements', function(){
       var result = fuzzy.filter('ab', ['aba', 'c', 'cacb']);
       expect(result).to.have.length(2);

--- a/test/fuzzy.test.js
+++ b/test/fuzzy.test.js
@@ -64,7 +64,6 @@ describe('fuzzy', function(){
       expect(result).to.equal('<r><e>active r<i><c>e');
     });
   });
-
   describe('.filter', function(){
     it('should return list untouched when the pattern is undefined', function() {
       arr = ['aba', 'c', 'cacb']

--- a/test/fuzzy.test.js
+++ b/test/fuzzy.test.js
@@ -68,17 +68,15 @@ describe('fuzzy', function(){
     it('should return list untouched when the pattern is undefined', function() {
       arr = ['aba', 'c', 'cacb']
       var result = fuzzy.filter(undefined, arr);
-      expect(result).to.include.members(arr)
+      expect(result).to.equal(arr)
     })
     it('should return an empty array when the array is undefined', function() {
       var result = fuzzy.filter('pattern', undefined);
       expect(result).to.deep.equal([])
-      expect(result).to.be.empty;
     })
     it('should return an empty array when the array is empty', function() {
       var result = fuzzy.filter('pattern', []);
       expect(result).to.deep.equal([])
-      expect(result).to.be.empty;
     })
     it('should return the index and matching array elements', function(){
       var result = fuzzy.filter('ab', ['aba', 'c', 'cacb']);


### PR DESCRIPTION
I use fuzzy on a backend project where the `pattern` and the `arr` are sometimes `undefined` or empty. Thought it'll be good to have some error handling and fallbacks. Without it, when you pass `undefined`, it breaks:

```
# When pattern is undefined
TypeError: Cannot read property 'toLowerCase' of undefined`
# When arr is undefined
TypeError: Cannot read property 'reduce' of undefined
```