### PR TITLE
Ignore examples when installing with bower

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -27,6 +27,7 @@
     "node_modules",
     "bower_components",
     "test",
-    "tests"
+    "tests",
+    "examples"
   ]
 }


### PR DESCRIPTION
I see `fuzzy` taking ~5 MB in my `bower_components`. This should fix that.