### PR TITLE
Fixed all broken github urls that were pointed to 404s.

### DIFF
--- a/component.json
+++ b/component.json
@@ -2,7 +2,7 @@
   "name": "fuzzy",
   "description": "small, standalone fuzzy search / fuzzy filter. browser or node",
   "version": "0.1.0",
-  "homepage": "https://github.com/myork/fuzzy",
+  "homepage": "https://github.com/mattyork/fuzzy",
   "author": {
     "name": "Matt York",
     "email": "york.matt@gmail.com",
@@ -10,15 +10,15 @@
   },
   "repository": {
     "type": "git",
-    "url": "git://github.com/myork/fuzzy.git"
+    "url": "git://github.com/mattyork/fuzzy.git"
   },
   "bugs": {
-    "url": "https://github.com/myork/fuzzy/issues"
+    "url": "https://github.com/mattyork/fuzzy/issues"
   },
   "licenses": [
     {
       "type": "MIT",
-      "url": "https://github.com/myork/fuzzy/blob/master/LICENSE-MIT"
+      "url": "https://github.com/mattyork/fuzzy/blob/master/LICENSE-MIT"
     }
   ],
   "main": "lib/fuzzy.js",

--- a/lib/fuzzy.js
+++ b/lib/fuzzy.js
@@ -1,6 +1,6 @@
 /*
  * Fuzzy
- * https://github.com/myork/fuzzy
+ * https://github.com/mattyork/fuzzy
  *
  * Copyright (c) 2012 Matt York
  * Licensed under the MIT license.


### PR DESCRIPTION
I was using fuzzy in an old project and was looking for it again yet had a very hard time due to these broken links.  Figured I would just make a quick PR to fix them.  Thanks for the great tool!
