### PR TITLE
Update the return type of `match`

### DIFF
--- a/lib/fuzzy.d.ts
+++ b/lib/fuzzy.d.ts
@@ -33,7 +33,7 @@ export declare function match(
   pattern: string,
   inputString: string,
   opts?: MatchOptions
-): MatchResult;
+): MatchResult | null;
 
 export interface FilterOptions<T> {
   pre?: string;


### PR DESCRIPTION
The `match` function can return `null` if there was no match, which was documented in the JSDoc, but not in the actual return type. The error has been fixed.